### PR TITLE
Detect AWS credentials automatically

### DIFF
--- a/priv/vmq_cloudwatch_metrics.schema
+++ b/priv/vmq_cloudwatch_metrics.schema
@@ -12,7 +12,7 @@
 ]}.
 
 
-%% @doc set the namespace for the metric data. 
+%% @doc set the namespace for the metric data.
 %% Namespaces that begin with "AWS/" are reserved for use by Amazon Web Services products.
 {mapping, "vmq_cloudwatch_metrics.namespace", "vmq_cloudwatch_metrics.namespace", [
                                                             {commented, "VerneMQ"},
@@ -40,6 +40,8 @@
                                                               {datatype, string}
                                                             ]}.
 
-
-
-
+%% @doc Set the AWS Profile.
+{mapping, "vmq_cloudwatch_metrics.aws_region", "vmq_cloudwatch_metrics.aws_profile", [
+                                                              {default, "default"},
+                                                              {datatype, string}
+                                                            ]}.

--- a/priv/vmq_cloudwatch_metrics.schema
+++ b/priv/vmq_cloudwatch_metrics.schema
@@ -15,7 +15,7 @@
 %% @doc set the namespace for the metric data. 
 %% Namespaces that begin with "AWS/" are reserved for use by Amazon Web Services products.
 {mapping, "vmq_cloudwatch_metrics.namespace", "vmq_cloudwatch_metrics.namespace", [
-                                                            {commented, "VerneMQ/Dev"},
+                                                            {commented, "VerneMQ"},
                                                             {default, ""},
                                                             {datatype, string}
 ]}.

--- a/priv/vmq_cloudwatch_metrics.schema
+++ b/priv/vmq_cloudwatch_metrics.schema
@@ -41,7 +41,7 @@
                                                             ]}.
 
 %% @doc Set the AWS Profile.
-{mapping, "vmq_cloudwatch_metrics.aws_region", "vmq_cloudwatch_metrics.aws_profile", [
+{mapping, "vmq_cloudwatch_metrics.aws_profile", "vmq_cloudwatch_metrics.aws_profile", [
                                                               {default, "default"},
                                                               {datatype, string}
                                                             ]}.

--- a/src/vmq_cloudwatch_metrics.app.src
+++ b/src/vmq_cloudwatch_metrics.app.src
@@ -16,9 +16,10 @@
      {cloudwatch_enabled, false},
      {interval, 60000},
      {namespace, "VerneMQ"},
+     {aws_profile, "default"},
+     {aws_region, "us-east-1"},
      {aws_access_key_id, ""},
-     {aws_secret_access_key, ""},
-     {aws_region, "us-east-1"}
+     {aws_secret_access_key, ""}
   ]},
   {modules, []},
   {maintainers, ["Dairon Medina Caro"]},

--- a/src/vmq_cloudwatch_metrics.erl
+++ b/src/vmq_cloudwatch_metrics.erl
@@ -74,7 +74,7 @@ init([]) ->
     {ok, AccessKeyID} = application:get_env(?APP, aws_access_key_id),
     {ok, SecretAccessKey} = application:get_env(?APP, aws_secret_access_key),
     {ok, Namespace} = application:get_env(?APP, namespace),
-    AWSConfig = case has_valid_credentials(AccessKeyID, SecretAccessKey) of
+    AWSConfig = case has_config_credentials(AccessKeyID, SecretAccessKey) of
         true ->
             lager:info("AWS credentials configured"),
             Conf = erlcloud_mon:new(AccessKeyID, SecretAccessKey),
@@ -272,16 +272,24 @@ value(V) when is_integer(V) -> float(V);
 value(V) when is_float(V)   -> V;
 value(_) -> 0.0.
 
-has_valid_credentials(undefined, _) ->
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Determines whether or not AWS Credentials are provided in the
+%% VerneMQ config.
+%% @end
+%%--------------------------------------------------------------------
+-spec has_config_credentials(iodata(), iodata()) -> boolean().
+has_config_credentials(undefined, _) ->
     false;
-has_valid_credentials(_, undefined) ->
+has_config_credentials(_, undefined) ->
     false;
-has_valid_credentials(undefined, undefined) ->
+has_config_credentials(undefined, undefined) ->
     false;
-has_valid_credentials(AccessKeyID, SecretAccessKey) when
-    is_list(AccessKeyID), is_list(SecretAccessKey) ->
-        case {AccessKeyID, SecretAccessKey} of
-            {"", ""} -> false;
-            _ -> true
-        end.
+has_config_credentials(AccessKeyID, SecretAccessKey) when
+is_list(AccessKeyID), is_list(SecretAccessKey) ->
+    case {AccessKeyID, SecretAccessKey} of
+        {"", ""} -> false;
+        _ -> true
+    end.
 

--- a/src/vmq_cloudwatch_metrics_cli.erl
+++ b/src/vmq_cloudwatch_metrics_cli.erl
@@ -28,7 +28,8 @@ register_config() ->
      "vmq_cloudwatch_metrics.namespace",
      "vmq_cloudwatch_metrics.aws_access_key_id",
      "vmq_cloudwatch_metrics.aws_secret_access_key",
-     "vmq_cloudwatch_metrics.aws_region"
+     "vmq_cloudwatch_metrics.aws_region",
+     "vmq_cloudwatch_metrics.aws_profile"
     ],
     [clique:register_config([Key],
         fun register_config_callback/3) || Key <- ConfigKeys


### PR DESCRIPTION
# Proposed Changes

This feature adds the ability to fetch the best available AWS credentials if they are not provided via the `vernemq.conf` file, attempting to find them in this order:

- Environment Variables
- User Profile
- Host Metadata

This eliminates the need to pass/encrypt credentials via Jenkins and makes the plugin work seamlessly in any AWS service without extra configs.

## Types of Changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] All tests pass locally with my changes
- [x] I have added necessary documentation (if needed)
- [x] I have linted my code with `rebar3 lint` before merging
